### PR TITLE
(fix): Move v2 modal to app level, remove timer

### DIFF
--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -4,7 +4,6 @@ import { Heading, IconButton, Text, Flex, useModal, TuneIcon, HistoryIcon } from
 import useI18n from 'hooks/useI18n'
 import SettingsModal from './SettingsModal'
 import RecentTransactionsModal from './RecentTransactionsModal'
-import UseV2ExchangeModal from '../UseV2ExchangeModal'
 
 interface PageHeaderProps {
   title: ReactNode
@@ -23,20 +22,8 @@ const Details = styled.div`
 
 const PageHeader = ({ title, description, children }: PageHeaderProps) => {
   const TranslateString = useI18n()
-  const [hasSeenModal, setHasSeenModal] = useState(false)
   const [onPresentSettings] = useModal(<SettingsModal translateString={TranslateString} />)
   const [onPresentRecentTransactions] = useModal(<RecentTransactionsModal translateString={TranslateString} />)
-  const [onPresentUseV2ExchangeModal] = useModal(<UseV2ExchangeModal />)
-
-  useEffect(() => {
-    const showModal = () => {
-      onPresentUseV2ExchangeModal()
-      setHasSeenModal(true)
-    }
-    if (!hasSeenModal) {
-      showModal()
-    }
-  }, [onPresentUseV2ExchangeModal, hasSeenModal])
 
   return (
     <StyledPageHeader>

--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState, useEffect } from 'react'
+import React, { ReactNode } from 'react'
 import styled from 'styled-components'
 import { Heading, IconButton, Text, Flex, useModal, TuneIcon, HistoryIcon } from '@pancakeswap-libs/uikit'
 import useI18n from 'hooks/useI18n'

--- a/src/components/UseV2ExchangeModal/index.tsx
+++ b/src/components/UseV2ExchangeModal/index.tsx
@@ -33,16 +33,8 @@ type UseV2ExchangeModalProps = {
 
 const UseV2ExchangeModal = ({ onDismiss = defaultOnDismiss }: UseV2ExchangeModalProps) => {
   const [isAcknowledged, setIsAcknowledged] = useState(false)
-  const [hasTimerPassed, setHasTimerPassed] = useState(false)
-  const [timerSecondsRemaining, setTimerSecondsRemaining] = useState(10)
 
   useEffect(() => {
-    const tick = () => {
-      setTimerSecondsRemaining((prevSeconds) => prevSeconds - 1)
-    }
-
-    const timerInterval = setInterval(() => tick(), 1000)
-
     const preventClickHandler = (e) => {
       e.stopPropagation()
       e.preventDefault()
@@ -53,18 +45,12 @@ const UseV2ExchangeModal = ({ onDismiss = defaultOnDismiss }: UseV2ExchangeModal
       el.addEventListener('click', preventClickHandler, true)
     })
 
-    if (timerSecondsRemaining <= 0) {
-      setHasTimerPassed(true)
-      clearInterval(timerInterval)
-    }
-
     return () => {
       document.querySelectorAll('[role="presentation"]').forEach((el) => {
         el.removeEventListener('click', preventClickHandler, true)
       })
-      clearInterval(timerInterval)
     }
-  }, [timerSecondsRemaining])
+  }, [])
 
   return (
     <Modal onDismiss={onDismiss} title="Use V2 Exchange" hideCloseButton>
@@ -93,14 +79,8 @@ const UseV2ExchangeModal = ({ onDismiss = defaultOnDismiss }: UseV2ExchangeModal
             </Text>
           </Flex>
         </StyledLabel>
-        <StyledButton
-          mt="24px"
-          width="100%"
-          variant="text"
-          disabled={!isAcknowledged || !hasTimerPassed}
-          onClick={onDismiss}
-        >
-          Continue to V1 Anyway {timerSecondsRemaining ? `(${timerSecondsRemaining})` : ''}
+        <StyledButton mt="24px" width="100%" variant="text" disabled={!isAcknowledged} onClick={onDismiss}>
+          Continue to V1 Anyway
         </StyledButton>
       </Box>
     </Modal>

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -2,7 +2,7 @@ import React, { Suspense, useEffect, useState } from 'react'
 import { HashRouter, Route, Switch } from 'react-router-dom'
 import styled from 'styled-components'
 import { Credentials, StringTranslations } from '@crowdin/crowdin-api-client'
-import { LangType } from '@pancakeswap-libs/uikit'
+import { LangType, useModal } from '@pancakeswap-libs/uikit'
 import VersionBar from 'components/VersionBar'
 import Popups from '../components/Popups'
 import Web3ReactManager from '../components/Web3ReactManager'
@@ -18,6 +18,7 @@ import { RedirectPathToSwapOnly } from './Swap/redirects'
 import { EN, allLanguages } from '../constants/localisation/languageCodes'
 import { LanguageContext } from '../hooks/LanguageContext'
 import { TranslationsContext } from '../hooks/TranslationsContext'
+import UseV2ExchangeModal from '../components/UseV2ExchangeModal'
 
 import Menu from '../components/Menu'
 import useGetDocumentTitlePrice from '../hooks/useGetDocumentTitlePrice'
@@ -48,12 +49,24 @@ export default function App() {
   const apiKey = `${process.env.REACT_APP_CROWDIN_APIKEY}`
   const projectId = parseInt(`${process.env.REACT_APP_CROWDIN_PROJECTID}`)
   const fileId = 6
-
   const credentials: Credentials = {
     token: apiKey,
   }
 
   const stringTranslationsApi = new StringTranslations(credentials)
+
+  const [hasSeenModal, setHasSeenModal] = useState(false)
+  const [onPresentUseV2ExchangeModal] = useModal(<UseV2ExchangeModal />)
+
+  useEffect(() => {
+    const showModal = () => {
+      onPresentUseV2ExchangeModal()
+      setHasSeenModal(true)
+    }
+    if (!hasSeenModal) {
+      showModal()
+    }
+  }, [onPresentUseV2ExchangeModal, hasSeenModal])
 
   const getStoredLang = (storedLangCode: string) => {
     return allLanguages.filter((language) => {


### PR DESCRIPTION
Preview - https://v1-modal-without-timer.netlify.app


- Timer removed
- Component moved to app level so it isn't triggered multiple times on the exchange site