### PR TITLE
fix(cake-price): Use LP for cake price not API

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -1,22 +1,20 @@
 import React, { useContext } from 'react'
-import { Menu as UikitMenu} from '@pancakeswap-libs/uikit'
+import { Menu as UikitMenu } from '@pancakeswap-libs/uikit'
 import { useWeb3React } from '@web3-react/core'
 import { allLanguages } from 'constants/localisation/languageCodes'
 import { LanguageContext } from 'hooks/LanguageContext'
 import useTheme from 'hooks/useTheme'
-import useGetPriceData from 'hooks/useGetPriceData'
 import useGetLocalProfile from 'hooks/useGetLocalProfile'
 import useAuth from 'hooks/useAuth'
+import useGetCakeBusdLpPrice from 'utils/useGetCakeBusdLpPrice'
 import links from './config'
-import { CAKE } from '../../constants'
 
 const Menu: React.FC = (props) => {
   const { account } = useWeb3React()
   const { login, logout } = useAuth()
   const { selectedLanguage, setSelectedLanguage } = useContext(LanguageContext)
   const { isDark, toggleTheme } = useTheme()
-  const priceData = useGetPriceData()
-  const cakePriceUsd = priceData ? Number(priceData.data[CAKE.address].price) : undefined
+  const cakeBusdPrice = useGetCakeBusdLpPrice()
   const profile = useGetLocalProfile()
 
   return (
@@ -30,7 +28,7 @@ const Menu: React.FC = (props) => {
       currentLang={selectedLanguage?.code || ''}
       langs={allLanguages}
       setLang={setSelectedLanguage}
-      cakePriceUsd={cakePriceUsd}
+      cakePriceUsd={cakeBusdPrice}
       profile={profile}
       {...props}
     />

--- a/src/hooks/useGetDocumentTitlePrice.ts
+++ b/src/hooks/useGetDocumentTitlePrice.ts
@@ -1,22 +1,19 @@
 import { useEffect } from 'react'
-import useGetPriceData from './useGetPriceData'
-import { CAKE } from '../constants'
+import useGetCakeBusdLpPrice from 'utils/useGetCakeBusdLpPrice'
 
 const useGetDocumentTitlePrice = () => {
-  const priceData = useGetPriceData()
+  const cakePriceBusd = useGetCakeBusdLpPrice()
 
-  const cakePriceUsd = priceData ? parseFloat(priceData.data[CAKE.address].price) : 0
-
-  const cakePriceUsdString =
-    Number.isNaN(cakePriceUsd) || cakePriceUsd === 0
+  const cakePriceBusdString =
+    Number.isNaN(cakePriceBusd) || cakePriceBusd === 0 || !cakePriceBusd
       ? ''
-      : ` - $${cakePriceUsd.toLocaleString(undefined, {
+      : ` - $${cakePriceBusd.toLocaleString(undefined, {
           minimumFractionDigits: 3,
           maximumFractionDigits: 3,
         })}`
 
   useEffect(() => {
-    document.title = `PancakeSwap${cakePriceUsdString}`
-  }, [cakePriceUsdString])
+    document.title = `PancakeSwap${cakePriceBusdString}`
+  }, [cakePriceBusdString])
 }
 export default useGetDocumentTitlePrice

--- a/src/utils/useGetCakeBusdLpPrice.ts
+++ b/src/utils/useGetCakeBusdLpPrice.ts
@@ -1,0 +1,16 @@
+import { useCurrency } from 'hooks/Tokens'
+import { useTradeExactIn } from 'hooks/Trades'
+import { tryParseAmount } from 'state/swap/hooks'
+
+const useGetCakeBusdLpPrice = () => {
+  const cakeAddress = '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82'
+  const busdAddress = '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56'
+  const inputCurrency = useCurrency(cakeAddress)
+  const outputCurrency = useCurrency(busdAddress)
+  const parsedAmount = tryParseAmount('1', inputCurrency ?? undefined)
+  const bestTradeExactIn = useTradeExactIn(parsedAmount, outputCurrency ?? undefined)
+  const price = bestTradeExactIn?.executionPrice.toSignificant(6)
+  return price ? parseFloat(price) : undefined
+}
+
+export default useGetCakeBusdLpPrice


### PR DESCRIPTION
Same as https://github.com/pancakeswap/pancake-swap-interface-v2/pull/26 on v2

- Create `useGetCakeBusdLpPrice` hook to fetch CAKE / BUSD price using the LP hooks
- Replace current instances of Cake / USD price (coming from API) with this new hook
